### PR TITLE
Address changes in accordance with mangadex version bump to 5.3.3 (+ bug fixes)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.3.2)
+    mangadex (5.3.3)
       activesupport (~> 6.1)
       psych (~> 4.0.1)
       rest-client (~> 2.1)

--- a/lib/mangadex/api/context.rb
+++ b/lib/mangadex/api/context.rb
@@ -6,6 +6,7 @@ module Mangadex
 
       @@user = nil
       @@version = nil
+      @@force_raw_requests = nil
 
       sig { returns(T.nilable(String)) }
       def self.version
@@ -57,6 +58,32 @@ module Mangadex
         with_user(nil) do
           yield
         end
+      end
+
+      def self.force_raw_requests(&block)
+        if block_given?
+          temp_force_raw_requests do
+            yield
+          end
+        else
+          !!@@force_raw_requests
+        end
+      end
+
+      def self.force_raw_requests=(value)
+        @@force_raw_requests = value
+      end
+
+      private
+
+      def self.temp_force_raw_requests(&block)
+        current_force_raw_requests = @@force_raw_requests
+        @@force_raw_requests = true
+        response = yield
+        @@force_raw_requests = current_force_raw_requests
+        response
+      ensure
+        @@force_raw_requests = current_force_raw_requests
       end
     end
   end

--- a/lib/mangadex/api/response.rb
+++ b/lib/mangadex/api/response.rb
@@ -7,6 +7,7 @@ module Mangadex
 
       attr_accessor :result, :response, :errors, :data
       attr_accessor :limit, :offset, :total
+      attr_accessor :raw_data
 
       def self.attributes_to_inspect
         %i(result errors limit offset total data)
@@ -44,6 +45,10 @@ module Mangadex
         Array(errors).any?
       end
 
+      def as_json(*)
+        Hash(raw_data)
+      end
+
       private
 
       def self.coerce_errors(data)
@@ -60,6 +65,7 @@ module Mangadex
               )
             end
           ),
+          raw_data: data,
         )
       end
 
@@ -75,6 +81,7 @@ module Mangadex
           result: data['result'],
           response: data['response'],
           data: klass.from_data(data['data'] || data),
+          raw_data: data,
         )
       end
 
@@ -97,6 +104,7 @@ module Mangadex
               end
             )
           ),
+          raw_data: data,
         )
       end
     end

--- a/lib/mangadex/author.rb
+++ b/lib/mangadex/author.rb
@@ -66,6 +66,8 @@ module Mangadex
     # @return [Mangadex::Api::Response] with a entity of author
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[Author]) }
     def self.get(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         format('/author/%{id}', id: id),
         Mangadex::Internal::Definition.validate(args, {
@@ -81,6 +83,8 @@ module Mangadex
     # @return [Mangadex::Api::Response] with a entity of author
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[Author]) }
     def self.update(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.put(
         format('/author/%{id}', id: id),
         payload: Mangadex::Internal::Definition.validate(args, {
@@ -98,6 +102,8 @@ module Mangadex
     # @return [Hash]
     sig { params(id: String).returns(Hash) }
     def self.delete(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         format('/author/%{id}', id: id)
       )
@@ -105,6 +111,10 @@ module Mangadex
 
     def self.inspect_attributes
       [:name]
+    end
+
+    class << self
+      alias_method :view, :get
     end
 
     # Indicates if this is an artist

--- a/lib/mangadex/chapter.rb
+++ b/lib/mangadex/chapter.rb
@@ -31,6 +31,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[Chapter]) }
     def self.get(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/chapter/%{id}' % {id: id},
         Mangadex::Internal::Definition.validate(args, {
@@ -41,6 +43,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[Chapter]) }
     def self.update(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.put(
         '/chapter/%{id}' % {id: id},
         payload: Mangadex::Internal::Definition.validate(args, {
@@ -56,9 +60,15 @@ module Mangadex
 
     sig { params(id: String).returns(Hash) }
     def self.delete(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         '/chapter/%{id}' % {id: id},
       )
+    end
+
+    class << self
+      alias_method :view, :get
     end
 
     sig { returns(String) }

--- a/lib/mangadex/content_rating.rb
+++ b/lib/mangadex/content_rating.rb
@@ -64,7 +64,7 @@ module Mangadex
 
     private
 
-    sig { params(value: T.any(T::Api::Text, T::Api::ContentRating)).void }
+    sig { params(value: T.any(T::Api::Text, T::Api::ContentRating)).returns(T.any(T::Api::Text, T::Api::ContentRating)) }
     def ensure_value!(value)
       return value if value.is_a?(ContentRating)
       return value if VALUES.include?(value)

--- a/lib/mangadex/cover_art.rb
+++ b/lib/mangadex/cover_art.rb
@@ -47,6 +47,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[CoverArt]) }
     def self.get(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/cover/%{id}' % {id: id},
         Mangadex::Internal::Definition.validate(args, {
@@ -57,6 +59,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[CoverArt]) }
     def self.edit(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.put(
         '/cover/%{id}' % {id: id},
         Mangadex::Internal::Definition.validate(args, {
@@ -69,9 +73,16 @@ module Mangadex
 
     sig { params(id: String).returns(Hash) }
     def self.delete(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         '/cover/%{id}' % {id: id},
       )
+    end
+
+    class << self
+      alias_method :view, :get
+      alias_method :update, :edit
     end
 
     sig { params(size: T::Api::Text).returns(T.nilable(String)) }

--- a/lib/mangadex/custom_list.rb
+++ b/lib/mangadex/custom_list.rb
@@ -24,6 +24,8 @@ module Mangadex
 
     sig { params(id: String).returns(Mangadex::Api::Response[CustomList]) }
     def self.get(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/list/%{id}' % {id: id},
       )
@@ -31,6 +33,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[CustomList]) }
     def self.update(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.put(
         '/list/%{id}' % {id: id},
         payload: Mangadex::Internal::Definition.validate(args, {
@@ -44,6 +48,8 @@ module Mangadex
 
     sig { params(id: String).returns(T::Boolean) }
     def self.delete(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         '/list/%{id}' % {id: id},
       )
@@ -51,6 +57,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[Chapter]) }
     def self.feed(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/list/%{id}/feed' % {id: id},
         Mangadex::Internal::Definition.chapter_list(args),
@@ -59,6 +67,8 @@ module Mangadex
 
     sig { params(id: String, list_id: String).returns(T::Boolean) }
     def self.add_manga(id, list_id:)
+      Mangadex::Internal::Definition.must(id)
+
       response = Mangadex::Internal::Request.post(
         '/manga/%{id}/list/%{list_id}' % {id: id, list_id: list_id},
       )
@@ -71,6 +81,8 @@ module Mangadex
 
     sig { params(id: String, list_id: String).returns(T::Boolean) }
     def self.remove_manga(id, list_id:)
+      Mangadex::Internal::Definition.must(id)
+
       response = Mangadex::Internal::Request.delete(
         '/manga/%{id}/list/%{list_id}' % {id: id, list_id: list_id},
       )
@@ -94,6 +106,8 @@ module Mangadex
 
     sig { params(user_id: String, args: T::Api::Arguments).returns(Mangadex::Api::Response[CustomList]) }
     def self.user_list(user_id, **args)
+      Mangadex::Internal::Definition.must(user_id)
+
       Mangadex::Internal::Request.get(
         '/user/%{id}/list' % {id: user_id},
         Mangadex::Internal::Definition.validate(args, {
@@ -101,6 +115,11 @@ module Mangadex
           offset: { accepts: Integer },
         }),
       )
+    end
+
+    class << self
+      alias_method :view, :get
+      alias_method :edit, :update
     end
 
     sig { params(id: String).returns(T::Boolean) }

--- a/lib/mangadex/internal/definition.rb
+++ b/lib/mangadex/internal/definition.rb
@@ -120,6 +120,19 @@ module Mangadex
           )
         end
 
+        def must(*args)
+          args = args.each_with_index.map do |arg, index|
+            ["arg_at_position_#{index}".to_sym, arg]
+          end.to_h
+
+          definition = args.keys.map do |key|
+            [key, { required: true }]
+          end.to_h
+
+          validate(args, definition)
+          args.values
+        end
+
         def validate(args, definition)
           args = Hash(args).with_indifferent_access
           definition = Hash(definition).with_indifferent_access
@@ -144,7 +157,7 @@ module Mangadex
           if errors.any?
             error_message = errors.map do |error|
               if error[:extra]
-                "params[:#{error[:extra]}] does not exist and cannot be passed to this request"
+                "paalidate_required!rams[:#{error[:extra]}] does not exist and cannot be passed to this request"
               elsif error[:message]
                 error[:message]
               else

--- a/lib/mangadex/internal/with_attributes.rb
+++ b/lib/mangadex/internal/with_attributes.rb
@@ -11,7 +11,8 @@ module Mangadex
           :id,
           :type,
           :attributes,
-          :relationships
+          :relationships,
+          :related_type
       
       class_methods do
         USING_ATTRIBUTES = {}
@@ -30,7 +31,7 @@ module Mangadex
           self.name.split('::').last.underscore
         end
 
-        def from_data(data)
+        def from_data(data, related_type: nil)
           base_class_name = self.name.gsub('::', '_')
           klass_name = self.name
           target_attributes_class_name = "#{base_class_name}_Attributes"
@@ -65,6 +66,7 @@ module Mangadex
             id: data['id'],
             type: data['type'] || self.type,
             attributes: attributes,
+            related_type: related_type,
           }
 
           initialize_hash.merge!({relationships: relationships}) if relationships.present?
@@ -110,6 +112,13 @@ module Mangadex
             else
               super
             end
+          elsif !related_type.nil?
+            return super unless method_name.end_with?("?")
+
+            looking_for_related = method_name.to_s.split("?").first
+            return super unless Mangadex::Relationship::RELATED_VALUES.include?(looking_for_related)
+
+            related_type == looking_for_related
           else
             super
           end

--- a/lib/mangadex/manga.rb
+++ b/lib/mangadex/manga.rb
@@ -66,6 +66,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(T::Api::MangaResponse) }
     def self.view(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/manga/%{id}' % {id: id},
         Mangadex::Internal::Definition.validate(args, {
@@ -76,6 +78,8 @@ module Mangadex
 
     sig { params(id: String).returns(T.any(Hash, Mangadex::Api::Response)) }
     def self.unfollow(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         '/manga/%{id}/follow' % {id: id},
       )
@@ -83,6 +87,8 @@ module Mangadex
 
     sig { params(id: String).returns(T.any(Hash, Mangadex::Api::Response)) }
     def self.follow(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.post(
         '/manga/%{id}/follow' % {id: id},
       )
@@ -90,6 +96,8 @@ module Mangadex
 
     sig { params(id: String, args: T::Api::Arguments).returns(T::Api::ChapterResponse) }
     def self.feed(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/manga/%{id}/feed' % {id: id},
         Mangadex::Internal::Definition.chapter_list(args),
@@ -128,6 +136,8 @@ module Mangadex
 
     sig { params(id: String).returns(T::Api::GenericResponse) }
     def self.reading_status(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.get(
         '/manga/%{id}/status' % {id: id},
       )
@@ -135,6 +145,8 @@ module Mangadex
 
     sig { params(id: String, status: String).returns(T::Api::GenericResponse) }
     def self.update_reading_status(id, status)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.post(
         '/manga/%{id}/status' % {id: id},
         payload: Mangadex::Internal::Definition.validate({status: status}, {
@@ -149,11 +161,15 @@ module Mangadex
     # Untested API endpoints
     sig { params(id: String, args: T::Api::Arguments).returns(T::Api::MangaResponse) }
     def self.update(id, **args)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.put('/manga/%{id}' % {id: id}, payload: args)
     end
 
     sig { params(id: String).returns(Hash) }
     def self.delete(id)
+      Mangadex::Internal::Definition.must(id)
+
       Mangadex::Internal::Request.delete(
         '/manga/%{id}' % {id: id},
       )
@@ -169,6 +185,8 @@ module Mangadex
 
     class << self
       alias_method :aggregate, :volumes_and_chapters
+      alias_method :get, :view
+      alias_method :edit, :update
     end
 
     sig { returns(T.nilable(ContentRating)) }

--- a/lib/mangadex/scanlation_group.rb
+++ b/lib/mangadex/scanlation_group.rb
@@ -48,6 +48,8 @@ module Mangadex
       end
 
       def view(id)
+        Mangadex::Internal::Definition.must(id)
+
         Mangadex::Internal::Request.get(
           '/group/%{id}' % {id: id},
           Mangadex::Internal::Definition.validate(args, {
@@ -90,6 +92,11 @@ module Mangadex
           '/group/%{id}/follow' % {id: id},
         )
       end
+    end
+
+    class << self
+      alias_method :get, :view
+      alias_method :edit, :update
     end
 
     def self.inspect_attributes

--- a/lib/mangadex/sorbet.rb
+++ b/lib/mangadex/sorbet.rb
@@ -17,7 +17,8 @@ module T
     MangaResponse = T.type_alias do
       T.any(
         Mangadex::Api::Response[Mangadex::Manga],
-        Mangadex::Api::Response[T::Array[Mangadex::Manga]]
+        Mangadex::Api::Response[T::Array[Mangadex::Manga]],
+        Hash,
       )
     end
     ChapterResponse = T.type_alias do

--- a/lib/mangadex/sorbet.rb
+++ b/lib/mangadex/sorbet.rb
@@ -18,7 +18,6 @@ module T
       T.any(
         Mangadex::Api::Response[Mangadex::Manga],
         Mangadex::Api::Response[T::Array[Mangadex::Manga]],
-        Hash,
       )
     end
     ChapterResponse = T.type_alias do

--- a/lib/mangadex/upload.rb
+++ b/lib/mangadex/upload.rb
@@ -28,6 +28,8 @@ module Mangadex
       alias_method :begin, :start
 
       def upload_images(upload_session_id)
+        Mangadex::Internal::Definition.must(upload_session_id)
+
         Mangadex::Internal::Request.post(
           '/upload/%{upload_session_id}' % {upload_session_id: upload_session_id},
           payload: Mangadex::Internal::Definition.validate(args, {
@@ -37,6 +39,8 @@ module Mangadex
       end
 
       def abandon(upload_session_id)
+        Mangadex::Internal::Definition.must(upload_session_id)
+
         Mangadex::Internal::Request.delete(
           '/upload/%{upload_session_id}' % {upload_session_id: upload_session_id},
         )
@@ -44,6 +48,8 @@ module Mangadex
       alias_method :stop, :abandon
 
       def commit(upload_session_id, **args)
+        Mangadex::Internal::Definition.must(upload_session_id)
+
         Mangadex::Internal::Request.post(
           '/upload/%{upload_session_id}/commit' % {upload_session_id: upload_session_id},
           payload: Mangadex::Internal::Definition.validate(args, {
@@ -54,6 +60,8 @@ module Mangadex
       end
 
       def delete_uploaded_image(upload_session_id, upload_session_file_id)
+        Mangadex::Internal::Definition.must(upload_session_id)
+
         Mangadex::Internal::Request.delete(
           '/upload/%{upload_session_id}/%{upload_session_file_id}' % {
             upload_session_id: upload_session_id,
@@ -63,6 +71,8 @@ module Mangadex
       end
 
       def delete_uploaded_images(upload_session_id, upload_session_file_ids)
+        Mangadex::Internal::Definition.must(upload_session_id)
+
         Mangadex::Internal::Request.delete(
           '/upload/%{upload_session_id}' % {upload_session_id: upload_session_id},
           payload: Array(upload_session_file_id),

--- a/lib/mangadex/user.rb
+++ b/lib/mangadex/user.rb
@@ -30,6 +30,8 @@ module Mangadex
 
     sig { params(id: String).returns(T::Boolean) }
     def self.follows_group(id)
+      Mangadex::Internal::Definition.must(id)
+
       data = Mangadex::Internal::Request.get(
         '/user/follows/group/%{id}' % {id: id},
         raw: true,
@@ -55,6 +57,8 @@ module Mangadex
 
     sig { params(id: String).returns(T::Boolean) }
     def self.follows_user(id)
+      Mangadex::Internal::Definition.must(id)
+
       return if Mangadex::Api::Context.user.nil?
 
       data = Mangadex::Internal::Request.get(
@@ -83,6 +87,8 @@ module Mangadex
 
     sig { params(id: String).returns(T::Boolean) }
     def self.follows_manga(id)
+      Mangadex::Internal::Definition.must(id)
+
       return if Mangadex::Api::Context.user.nil?
 
       data = Mangadex::Internal::Request.get(

--- a/lib/mangadex/version.rb
+++ b/lib/mangadex/version.rb
@@ -3,7 +3,7 @@ module Mangadex
   module Version
     MAJOR = "5"
     MINOR = "3"
-    TINY = "2"
+    TINY = "3"
     PATCH = nil
 
     STRING = [MAJOR, MINOR, TINY].compact.join('.')


### PR DESCRIPTION
### Changed (on Mangadex)

#### Added

- Add social links to Author 
- Add ScanlationGroup alt names field

#### More info on Discord [here](https://discord.com/channels/403905762268545024/839817812012826644/891784882630582282).


### My changes

- Add `related` to `Mangadex::Relationship`
  - All relationships now will respond to the type of the relationship (`related`) ending with a "?"
  - This includes `Mangadex::Relationship` as well as instanciated relationships (a `related_type` will be available then)

- Internal changes
  - Implement `Mangadex::Internal::Definition.must(*args)` to make sure that every argument is not empty. No, this is not the same as sorbet's `T.must`.
  - This is now used and enforced on every API call that requires some sort of ID to be present. Empty strings (`""`) may not return the data you want. Example: `Mangadex::Manga.list('')` would call `GET https://api.mangadex.org/manga/` which is the same as `Mangadex::Manga.list`!

- Debugging responses: this is not _ideal_ but here are two options:
  1) Use when contributing to the gem: All requests will return raw data (you must comment out the `sig` method signature to make your life easier, for now at least...). You can set it temporarily with `Mangadex::Api::Context.force_raw_data { #block } or by setting `Mangadex::Api::Context.force_raw_data = true`.
  2) Use when you're working on your own project: `Mangadex::Api::Response.raw_data` Every response now should have a `raw_data` field which is the data that was returned from the server. I'm working toward adding that raw data to _every_ object layer.
    - Every response now responds to `.as_json(*)` which simply returns `raw_data`.

- Developer experience
  - Every API call should now be consistent:
    - When fetching a resource, you can use `#get` or `#view`. Example: `Mangadex::Manga.view('...')` or `Mangadex::Manga.get('...')`
    - When editing a resource, you can use `#edit` or `#update`.
  - Why was it not consistent? I was following the API docs, which are not 100% consistent.
  - More alias to come