### PR TITLE
Added Statistic Endpoint to Mangadex API

### DIFF
--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -1,0 +1,21 @@
+# typed: false
+
+module Mangadex
+  class Statistic < MangadexObject
+    has_attributes \
+      :rating,
+      :average,
+      :bayesian,
+      :distribution,
+      :follows
+
+    sig { params(uuid: String).returns(T::Api::GenericResponse) }
+    def self.get(uuid)
+      Mangadex::Internal::Definition.must(uuid)
+
+      Mangadex::Internal::Request.get(
+        '/statistics/manga/%{uuid}' % {uuid: uuid},
+      )
+    end
+  end
+end

--- a/lib/mangadex/types.rb
+++ b/lib/mangadex/types.rb
@@ -20,6 +20,7 @@ require_relative "tag"
 require_relative "scanlation_group"
 require_relative "report_reason"
 require_relative "rating"
+require_relative "statistic"
 
 # Relationship
 require_relative "relationship"


### PR DESCRIPTION
Didn't actually do https://api.mangadex.org/docs/docs/statistics/#find-statistics-about-given-manga. That one's broken, try it on swagger: https://api.mangadex.org/docs/swagger.html#/

Test manga ids: 7dbc59db-6c77-4084-94ec-a38e0826faab and ce7cd7b0-e595-4f0d-98e8-447da10d652d

Try them individually, it works. Together, it doesn't. Mangadex needs to fix it.

Running the GET on statistics on console works though. Would appreciate it this can be reviewed, merged, and pushed if possible. I need to use statistics in my own project. Thanks!