### PR TITLE
Add fetch multiple statistic for multiple manga

### DIFF
--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -17,5 +17,17 @@ module Mangadex
         '/statistics/manga/%{uuid}' % {uuid: uuid},
       )
     end
+
+    sig { params(args: T::Api::Arguments).returns(T::Api::GenericResponse) }
+    def self.list(**args)
+      to_a = Mangadex::Internal::Definition.converts(:to_a)
+
+      Mangadex::Internal::Request.get(
+        '/statistics/manga',
+        Mangadex::Internal::Definition.validate(args, {
+          manga: { accepts: [String], converts: to_a },
+        })
+      )
+    end
   end
 end


### PR DESCRIPTION
This PR adds support for this: https://api.mangadex.org/docs/docs/statistics/#find-statistics-about-given-manga

Follow up to #38 

cc @royalgiant 

