### PR TITLE
Fix empty filters and check token call

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,20 @@
+name: Publish Gem
+
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Release Gem
+        if: contains(github.ref, 'refs/tags/v')
+        uses: cadwallion/publish-rubygems-action@master
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
+          RELEASE_COMMAND: rake release

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.7.5)
+    mangadex (5.7.5.1)
       psych (~> 4.0.1)
       rest-client (~> 2.1)
       sorbet-runtime

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.6.0.1)
+    mangadex (5.7.5)
       psych (~> 4.0.1)
       rest-client (~> 2.1)
       sorbet-runtime
@@ -47,7 +47,7 @@ GEM
     rspec-support (3.12.0)
     sorbet (0.5.10535)
       sorbet-static (= 0.5.10535)
-    sorbet-runtime (0.5.10535)
+    sorbet-runtime (0.5.10539)
     sorbet-static (0.5.10535-x86_64-linux)
     stringio (3.0.2)
     unf (0.1.4)

--- a/lib/mangadex/auth.rb
+++ b/lib/mangadex/auth.rb
@@ -58,12 +58,7 @@ module Mangadex
 
     sig { returns(Hash) }
     def self.check_token
-      JSON.parse(
-        Mangadex::Internal::Request.get(
-          '/auth/check',
-          raw: true,
-        )
-      )
+      Mangadex::Internal::Request.get('/auth/check')
     end
 
     sig { returns(T.any(T::Boolean, Mangadex::Api::Response)) }

--- a/lib/mangadex/manga.rb
+++ b/lib/mangadex/manga.rb
@@ -32,7 +32,7 @@ module Mangadex
       Mangadex::Internal::Request.get(
         '/manga',
         Mangadex::Internal::Definition.validate(args, {
-          limit: { accepts: Integer },
+          limit: { accepts: Integer, converts: :to_i },
           offset: { accepts: Integer },
           title: { accepts: String },
           author_or_artist: { accepts: String },

--- a/lib/mangadex/sorbet.rb
+++ b/lib/mangadex/sorbet.rb
@@ -7,12 +7,14 @@ module T
     Text = T.type_alias { T.any(String, Symbol) }
 
     Arguments = T.type_alias do
-      T.any(
-        Text,
-        T::Array[Text],
-        Integer,
-        T::Hash[Text, Text],
-        Mangadex::ContentRating,
+      T.nilable(
+        T.any(
+          Text,
+          T::Array[Text],
+          Integer,
+          T::Hash[Text, Text],
+          Mangadex::ContentRating,
+        )
       )
     end
     MangaResponse = T.type_alias do

--- a/lib/mangadex/version.rb
+++ b/lib/mangadex/version.rb
@@ -4,7 +4,7 @@ module Mangadex
     MAJOR = "5"
     MINOR = "7"
     TINY = "5"
-    PATCH = nil
+    PATCH = "1"
 
     STRING = [MAJOR, MINOR, TINY].compact.join('.')
     FULL = [MAJOR, MINOR, TINY, PATCH].compact.join('.')


### PR DESCRIPTION
This PR:
- Fixes an issue with `Mangadex::Auth.check_token` where `JSON.parse` was not necessary
- Ignores empty parameters when build query parameters (only when validation occurs)
  - empty strings
  - `nil` values
- (internal) Makes use of Symbol-based procs to make the code easier to read when validating params
