### PR TITLE
Fix NoMethodError when logging in with bad credentials

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.7.5.2)
+    mangadex (5.7.5.3)
       psych (~> 4.0.1)
       rest-client (~> 2.1)
       sorbet-runtime
@@ -47,7 +47,7 @@ GEM
     rspec-support (3.12.0)
     sorbet (0.5.10539)
       sorbet-static (= 0.5.10539)
-    sorbet-runtime (0.5.10539)
+    sorbet-runtime (0.5.10554)
     sorbet-static (0.5.10539-x86_64-linux)
     stringio (3.0.2)
     unf (0.1.4)

--- a/lib/mangadex/auth.rb
+++ b/lib/mangadex/auth.rb
@@ -27,6 +27,14 @@ module Mangadex
         }),
       )
 
+      if response.is_a?(Mangadex::Api::Response) && response.result == "error"
+        if block_given?
+          return yield(response)
+        else
+          return response
+        end
+      end
+
       session_valid_until = Time.now + (15 * 60)
 
       session = response.dig('token', 'session')


### PR DESCRIPTION
Writing this in the console:

```ruby
Mangadex::Auth.login(username: 'test', password: 'invalidpassword')
```

yields

```
[Mangadex::Internal::Request] POST https://api.mangadex.org/auth/login Payload: {"password":"[REDACTED]","username":"test"}
[Mangadex::Internal::Request] took 409 ms                                               
/gems/ruby/3.0.0/gems/mangadex-5.7.5.3/lib/mangadex/internal/with_attributes.rb:127:in `method_missing': undefined method `dig' for #<Mangadex::Api::Response:62880 @result="error" @errors="[#<Mangadex::Api::Response::Error:62900 @id="9c346772-7b14-5982-b4b6-7b5888522762" @status="400" @title="validation_exception" @detail="Error validating /password: Must be at least 8 characters long">]"> (NoMethodError)
```

This PR fixes this problem.