### PR TITLE
Prepend `Bearer` to Authorization headers

### DIFF
--- a/lib/mangadex/auth.rb
+++ b/lib/mangadex/auth.rb
@@ -40,7 +40,7 @@ module Mangadex
       session = response.dig('token', 'session')
       refresh = response.dig('token', 'refresh')
 
-      mangadex_user = Mangadex::Internal::Request.get('/user/me', headers: { Authorization: session })
+      mangadex_user = Mangadex::Internal::Request.get('/user/me', headers: { Authorization: "Bearer #{session}" })
 
       user = Mangadex::Api::User.new(
         mangadex_user_id: mangadex_user.data.id,

--- a/lib/mangadex/internal/request.rb
+++ b/lib/mangadex/internal/request.rb
@@ -128,7 +128,7 @@ module Mangadex
         return headers if Mangadex.context.user.nil?
 
         headers.merge({
-          Authorization: Mangadex.context.user.session,
+          Authorization: "Bearer #{Mangadex.context.user.session}",
         })
       end
 


### PR DESCRIPTION
There was a change in the API looks like, we need to add 'Bearer ' + session in order to get an OK response back

- Mangadex::Internal::Request.get('/user/me', headers: { Authorization: session }) # in 'lib/mangadex/auth.rb'
- headers.merge({
          Authorization: Mangadex.context.user.session,
        }) # in request.rb under request_headers

no longer worked as Mangadex required the adding of 'Bearer ' in front of the session tokens.

Without Bearer would result in a 401 Unauthorized error.

This PR fixes this problem