### PR TITLE
Bump to version 5.8.0

### DIFF
--- a/lib/mangadex/version.rb
+++ b/lib/mangadex/version.rb
@@ -2,9 +2,9 @@
 module Mangadex
   module Version
     MAJOR = "5"
-    MINOR = "7"
-    TINY = "5"
-    PATCH = "3"
+    MINOR = "8"
+    TINY = "0"
+    PATCH = nil
 
     STRING = [MAJOR, MINOR, TINY].compact.join('.')
     FULL = [MAJOR, MINOR, TINY, PATCH].compact.join('.')


### PR DESCRIPTION
This is a "transitive" bump to 5.8.0 to stay up to date with the existing Mangadex version. It also contains the changes below:

- https://github.com/thedrummeraki/mangadex/pull/64
- https://github.com/thedrummeraki/mangadex/pull/93

