### PR TITLE
[5.9.0] Add support for threads and refactor statistics

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.8.0)
+    mangadex (5.9.0)
       psych (~> 4.0.1)
       rest-client (~> 2.1)
       sorbet-runtime
@@ -47,7 +47,7 @@ GEM
     rspec-support (3.12.0)
     sorbet (0.5.10539)
       sorbet-static (= 0.5.10539)
-    sorbet-runtime (0.5.10597)
+    sorbet-runtime (0.5.10626)
     sorbet-static (0.5.10539-x86_64-linux)
     stringio (3.0.4)
     unf (0.1.4)

--- a/lib/mangadex/api/response.rb
+++ b/lib/mangadex/api/response.rb
@@ -36,6 +36,8 @@ module Mangadex
           coerce_entity(data)
         elsif data['response'] == 'collection'
           coerce_collection(data)
+        elsif data.keys.include?('statistics')
+          coerce_statistics(data)
         else
           data
         end
@@ -140,6 +142,13 @@ module Mangadex
             )
           ),
           raw_data: data,
+        )
+      end
+
+      def self.coerce_statistics(data)
+        new(
+          result: data['result'],
+          data: Mangadex::Statistic.from_data(data['statistics']),
         )
       end
     end

--- a/lib/mangadex/api/response.rb
+++ b/lib/mangadex/api/response.rb
@@ -111,7 +111,10 @@ module Mangadex
 
         # Derive the class name from the type. "Convention over configuration"
         class_from_data = "Mangadex::#{object_type.split('_').collect(&:capitalize).join}"
-        return unless Object.const_defined?(class_from_data)
+        unless Object.const_defined?(class_from_data)
+          warn("Expected class #{class_from_data} to be defined")
+          return
+        end
 
         klass = Object.const_get(class_from_data)
         new(

--- a/lib/mangadex/internal/with_attributes.rb
+++ b/lib/mangadex/internal/with_attributes.rb
@@ -62,6 +62,9 @@ module Mangadex
 
           if direct
             symbolized_data = data.symbolize_keys
+            symbolized_data.transform_keys! do |key|
+              Mangadex::Utils.underscore(key)
+            end
             keys = symbolized_data.keys
             keys.each do |key|
               attr_accessor key

--- a/lib/mangadex/manga.rb
+++ b/lib/mangadex/manga.rb
@@ -224,5 +224,20 @@ module Mangadex
       chapter_args = args.merge({manga: id})
       Chapter.list(**chapter_args)
     end
+
+    sig { returns(T::Boolean) }
+    def has_comments?
+      !comments_info.nil?
+    end
+
+    def statistics
+      @statistics ||= Mangadex::Statistic.get(id).data
+    end
+    alias :stats :statistics
+
+    def comments_info
+      statistics.comments
+    end
+    alias :comments :comments_info
   end
 end

--- a/lib/mangadex/manga.rb
+++ b/lib/mangadex/manga.rb
@@ -227,7 +227,7 @@ module Mangadex
 
     sig { returns(T::Boolean) }
     def has_comments?
-      !comments_info.nil?
+      !comments_info.nil? && comments_info.repliesCount > 0
     end
 
     def statistics

--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -2,12 +2,38 @@
 
 module Mangadex
   class Statistic < MangadexObject
-    has_attributes \
+    class Rating < MangadexObject
+      has_attributes \
+        :average,
+        :bayesian,
+        :distribution
+    end
+
+    class Comments < MangadexObject
+      has_attributes \
+        :threadId,
+        :repliesCount
+
+      def self.attributes_to_inspect
+        [:id, :threadId, :repliesCount]
+      end
+    end
+
+    attr_accessor \
       :rating,
-      :average,
-      :bayesian,
-      :distribution,
-      :follows
+      :follows,
+      :comments
+
+    class << self
+      def from_data(data)
+        statistics = data[data.keys.first]
+        new(
+          rating: Mangadex::Statistic::Rating.from_data(statistics['rating'], direct: true),
+          comments: Mangadex::Statistic::Comments.from_data(statistics['comments'], direct: true),
+          follows: statistics['follows'],
+        )
+      end
+    end
 
     sig { params(uuid: String).returns(T::Api::GenericResponse) }
     def self.get(uuid)

--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -30,31 +30,44 @@ module Mangadex
 
     class << self
       def from_data(data)
-        statistics = data[data.keys.first]
-        new(
-          rating: Mangadex::Statistic::Rating.from_data(statistics['rating'], direct: true),
-          comments: Mangadex::Statistic::Comments.from_data(statistics['comments'], direct: true),
-          follows: statistics['follows'],
-        )
+        results = if data.is_a?(Array)
+          data.map do |item|
+            from_data(item)
+          end
+        else
+          data.keys.map do |manga_id|
+            statistics = data[manga_id]
+            new(
+              rating: Mangadex::Statistic::Rating.from_data(statistics['rating'], direct: true),
+              comments: Mangadex::Statistic::Comments.from_data(statistics['comments'], direct: true),
+              follows: statistics['follows'],
+            )
+          end
+        end
+
+        return results.first if results.length == 1
+        Mangadex::Api::Response::Collection.new(results)
       end
     end
 
-    sig { params(uuid: String).returns(T::Api::GenericResponse) }
-    def self.get(uuid)
+    sig { params(uuid: String, raw: T::Boolean).returns(T::Api::GenericResponse) }
+    def self.get(uuid, raw: false)
       Mangadex::Internal::Definition.must(uuid)
 
       Mangadex::Internal::Request.get(
         '/statistics/manga/%{uuid}' % {uuid: uuid},
+        raw: raw,
       )
     end
 
-    sig { params(args: T::Api::Arguments).returns(T::Api::GenericResponse) }
-    def self.list(**args)
+    sig { params(raw: T::Boolean, args: T::Api::Arguments).returns(T::Api::GenericResponse) }
+    def self.list(raw: false, **args)
       Mangadex::Internal::Request.get(
         '/statistics/manga',
         Mangadex::Internal::Definition.validate(args, {
           manga: { accepts: [String], converts: :to_a },
-        })
+        }),
+        raw: raw,
       )
     end
 

--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -7,6 +7,10 @@ module Mangadex
         :average,
         :bayesian,
         :distribution
+
+      def self.attributes_to_inspect
+        [:average, :bayesian]
+      end
     end
 
     class Comments < MangadexObject
@@ -52,6 +56,10 @@ module Mangadex
           manga: { accepts: [String], converts: :to_a },
         })
       )
+    end
+
+    def self.attributes_to_inspect
+      [:follows, :rating, :comments]
     end
   end
 end

--- a/lib/mangadex/statistic.rb
+++ b/lib/mangadex/statistic.rb
@@ -15,11 +15,11 @@ module Mangadex
 
     class Comments < MangadexObject
       has_attributes \
-        :threadId,
-        :repliesCount
+        :thread_id,
+        :replies_count
 
       def self.attributes_to_inspect
-        [:id, :threadId, :repliesCount]
+        [:replies_count]
       end
     end
 

--- a/lib/mangadex/thread.rb
+++ b/lib/mangadex/thread.rb
@@ -1,0 +1,24 @@
+module Mangadex
+  class Thread < MangadexObject
+    has_attributes \
+      :replies_count
+
+    class << self
+      def create(type:, id:)
+        payload = {type: type, id: id}
+        Mangadex::Internal::Request.post(
+          '/forums/thread',
+          payload: Mangadex::Internal::Definition.validate(payload, {
+            type: { accepts: %w(manga group chapter), converts: :to_s, required: true },
+            id: { accepts: String, required: true },
+          }),
+          auth: true,
+        )
+      end
+    end
+
+    def self.attributes_to_inspect
+      [:id, :type, :replies_count]
+    end
+  end
+end

--- a/lib/mangadex/types.rb
+++ b/lib/mangadex/types.rb
@@ -22,6 +22,7 @@ require_relative "report_reason"
 require_relative "report"
 require_relative "rating"
 require_relative "statistic"
+require_relative "thread"
 
 # Relationship
 require_relative "relationship"

--- a/lib/mangadex/utils.rb
+++ b/lib/mangadex/utils.rb
@@ -10,9 +10,13 @@ module Mangadex
       end
 
       def underscore(string)
-        string.gsub(/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
+        is_symbol = string.kind_of?(Symbol)
+        data = string.to_s
+        result = data.gsub(/([A-Z]+)(?=[A-Z][a-z])|([a-z\d])(?=[A-Z])/) do
           ($1 || $2) << "_"
         end.tr('-', '_').downcase
+
+        is_symbol ? result.to_sym : result
       end
     end
   end

--- a/lib/mangadex/version.rb
+++ b/lib/mangadex/version.rb
@@ -2,7 +2,7 @@
 module Mangadex
   module Version
     MAJOR = "5"
-    MINOR = "8"
+    MINOR = "9"
     TINY = "0"
     PATCH = nil
 

--- a/spec/mangadex/internal/with_attributes_spec.rb
+++ b/spec/mangadex/internal/with_attributes_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe Mangadex::Internal::WithAttributes do
       expect(result.attributes.d).to be_nil
     end
 
+    it 'can set other attributes when direct' do
+      data = { e: 'sei' }
+      result = Dummy.from_data(data, direct: true)
+
+      expect(result.e).to eq('sei')
+    end
+
     it 'creates the special attribute class' do
       result = Dummy.from_data({
         attributes: {


### PR DESCRIPTION
## Description

This PR bumps to version 5.9.0 and adds API support for forum threads.

- de9f87f5daf0ba2d21679c422be2e0605d294c76
- 307c4d85cf1056ed9468a0a7675d1d1e42303227

## Breaking changes

Statistics that were implemented in #38 now return a `Mangadex::Statistic` object instead of a `Hash`. 
> If your code relies on statistics being a hash:

```ruby
# For one manga
Mangadex::Statistic.get(..., raw: true)

# For multiple manga
Mangadex::Statistic.list({manga: [...]}, raw: true)
```

You can now get stats like this:

```ruby
manga = Mangadex::Manga.get('d86cf65b-5f6c-437d-a0af-19a31f94ec55').data
statistics = manga.statistics
# => #<Mangadex::Statistic ...>
```

Get manga follow count:
```ruby
statistics.follows
# => 10000
```

Get manga comment info:
```ruby
statistics.comments
# => #<Mangadex::Statistic::Comments ...>
statistics.comments.replies_count
# => 1000
```

Get manga rating info:
```ruby
statistics.rating
# => #<Mangadex::Statistic::Rating ...>
statistics.rating.average
# => 7
statistics.rating.bayesian
# => 7
statistics.rating.distribution
# => {"1" => 10, "2" => 20, ...}
```

