### PR TITLE
Bump to version 5.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mangadex (5.9.0)
+    mangadex (5.10.0)
       psych (>= 4.0.1, < 5.2.0)
       rest-client (~> 2.1)
       sorbet-runtime
@@ -19,7 +19,7 @@ GEM
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     netrc (0.11.0)
     pry (0.14.2)
       coderay (~> 1.1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   gem:
     build: .
-    command: bash
+    command: bin/console
     stdin_open: true
     tty: true
     volumes:

--- a/lib/mangadex/internal/definition.rb
+++ b/lib/mangadex/internal/definition.rb
@@ -4,6 +4,7 @@ require_relative "definitions/accepts"
 
 require_relative "definitions/base"
 require_relative "definitions/content_rating"
+require_relative "definitions/year"
 
 module Mangadex
   module Internal

--- a/lib/mangadex/internal/definitions/year.rb
+++ b/lib/mangadex/internal/definitions/year.rb
@@ -1,0 +1,28 @@
+# typed: false
+
+module Mangadex
+  module Internal
+    module Definitions
+      class Year < Base
+        def initialize(value)
+          super(
+            value,
+            key: :year,
+            accepts: Accepts.new(
+              array: ["none"],
+              class: Integer,
+              condition: :or,
+            ),
+            required: false,
+          )
+        end
+
+        def validate_accepts
+          @accepts.validate!(converted_value)
+        rescue ArgumentError => error
+          add_error(error.message)
+        end
+      end
+    end
+  end
+end

--- a/lib/mangadex/manga.rb
+++ b/lib/mangadex/manga.rb
@@ -36,7 +36,7 @@ module Mangadex
           author_or_artist: { accepts: String },
           authors: { accepts: [String], converts: :to_a },
           artists: { accepts: [String], converts: :to_a },
-          year: { accepts: Integer },
+          year: Mangadex::Internal::Definitions::Year,
           included_tags: { accepts: [String], converts: :to_a },
           included_tags_mode: { accepts: %w(OR AND) },
           excluded_tags: { accepts: [String], converts: :to_a },

--- a/lib/mangadex/scanlation_group.rb
+++ b/lib/mangadex/scanlation_group.rb
@@ -17,6 +17,7 @@ module Mangadex
       :focused_languages,
       :publish_delay,
       :inactive,
+      :ex_licensed,
       :manga_updates,
       :version,
       :created_at,

--- a/lib/mangadex/version.rb
+++ b/lib/mangadex/version.rb
@@ -2,7 +2,7 @@
 module Mangadex
   module Version
     MAJOR = "5"
-    MINOR = "9"
+    MINOR = "10"
     TINY = "0"
     PATCH = nil
 


### PR DESCRIPTION
#238 

### Testing

- Manga can now be filtered by "none" (ie: no year set on manga)
<img width="1230" alt="image" src="https://github.com/thedrummeraki/mangadex/assets/14348784/40d82ee8-3d0e-42cb-bb7b-1775006631fa">
- ScanlationGroup now has `ex_licensed` attribute